### PR TITLE
Update Android Gradle plugin requirements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.0"
+agp = "8.9.1"
 kotlin = "1.9.24"
 coreKtx = "1.17.0"
 junit = "4.13.2"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Sun Sep 28 20:39:35 BST 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Summary
- bump the Android Gradle plugin version alias to 8.9.1 to satisfy androidx.core requirements
- update the Gradle wrapper distribution to 8.10.2 to match the new AGP baseline

## Testing
- `./gradlew help` *(fails: proxy prevented downloading Gradle distribution)*

------
https://chatgpt.com/codex/tasks/task_e_68d99322f59483299672ae1c8a6af7d5