### PR TITLE
Generate Earth texture procedurally

### DIFF
--- a/app/src/main/cpp/Renderer.h
+++ b/app/src/main/cpp/Renderer.h
@@ -2,6 +2,8 @@
 #define ANDROIDGLINVESTIGATIONS_RENDERER_H
 
 #include <EGL/egl.h>
+#include <array>
+#include <cstdint>
 #include <memory>
 
 #include "Model.h"
@@ -21,7 +23,14 @@ public:
             context_(EGL_NO_CONTEXT),
             width_(0),
             height_(0),
-            shaderNeedsNewProjectionMatrix_(true) {
+            shaderNeedsNewProjectionMatrix_(true),
+            viewNeedsUpdate_(true),
+            modelNeedsUpdate_(true),
+            rotationX_(0.f),
+            rotationY_(0.f),
+            activePointerId_(-1),
+            lastTouchX_(0.f),
+            lastTouchY_(0.f) {
         initRenderer();
     }
 
@@ -66,9 +75,21 @@ private:
     EGLint height_;
 
     bool shaderNeedsNewProjectionMatrix_;
+    bool viewNeedsUpdate_;
+    bool modelNeedsUpdate_;
 
     std::unique_ptr<Shader> shader_;
     std::vector<Model> models_;
+
+    std::array<float, 16> projectionMatrix_{};
+    std::array<float, 16> viewMatrix_{};
+    std::array<float, 16> modelMatrix_{};
+
+    float rotationX_;
+    float rotationY_;
+    int32_t activePointerId_;
+    float lastTouchX_;
+    float lastTouchY_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_RENDERER_H

--- a/app/src/main/cpp/Shader.cpp
+++ b/app/src/main/cpp/Shader.cpp
@@ -9,7 +9,11 @@ Shader *Shader::loadShader(
         const std::string &fragmentSource,
         const std::string &positionAttributeName,
         const std::string &uvAttributeName,
-        const std::string &projectionMatrixUniformName) {
+        const std::string &modelMatrixUniformName,
+        const std::string &viewMatrixUniformName,
+        const std::string &projectionMatrixUniformName,
+        const std::string &lightDirectionUniformName,
+        const std::string &textureUniformName) {
     Shader *shader = nullptr;
 
     GLuint vertexShader = loadShader(GL_VERTEX_SHADER, vertexSource);
@@ -49,20 +53,43 @@ Shader *Shader::loadShader(
             // indices with layout= in your shader, but it is not done in this sample
             GLint positionAttribute = glGetAttribLocation(program, positionAttributeName.c_str());
             GLint uvAttribute = glGetAttribLocation(program, uvAttributeName.c_str());
+            GLint modelMatrixUniform = glGetUniformLocation(
+                    program,
+                    modelMatrixUniformName.c_str());
+            GLint viewMatrixUniform = glGetUniformLocation(
+                    program,
+                    viewMatrixUniformName.c_str());
             GLint projectionMatrixUniform = glGetUniformLocation(
                     program,
                     projectionMatrixUniformName.c_str());
+            GLint lightDirectionUniform = glGetUniformLocation(
+                    program,
+                    lightDirectionUniformName.c_str());
+            GLint textureUniform = glGetUniformLocation(
+                    program,
+                    textureUniformName.c_str());
 
             // Only create a new shader if all the attributes are found.
             if (positionAttribute != -1
                 && uvAttribute != -1
-                && projectionMatrixUniform != -1) {
+                && modelMatrixUniform != -1
+                && viewMatrixUniform != -1
+                && projectionMatrixUniform != -1
+                && lightDirectionUniform != -1
+                && textureUniform != -1) {
 
                 shader = new Shader(
                         program,
                         positionAttribute,
                         uvAttribute,
-                        projectionMatrixUniform);
+                        modelMatrixUniform,
+                        viewMatrixUniform,
+                        projectionMatrixUniform,
+                        lightDirectionUniform,
+                        textureUniform);
+                glUseProgram(program);
+                glUniform1i(textureUniform, 0);
+                glUseProgram(0);
             } else {
                 glDeleteProgram(program);
             }
@@ -149,6 +176,18 @@ void Shader::drawModel(const Model &model) const {
     glDisableVertexAttribArray(position_);
 }
 
-void Shader::setProjectionMatrix(float *projectionMatrix) const {
-    glUniformMatrix4fv(projectionMatrix_, 1, false, projectionMatrix);
+void Shader::setModelMatrix(const float *modelMatrix) const {
+    glUniformMatrix4fv(modelMatrix_, 1, GL_FALSE, modelMatrix);
+}
+
+void Shader::setViewMatrix(const float *viewMatrix) const {
+    glUniformMatrix4fv(viewMatrix_, 1, GL_FALSE, viewMatrix);
+}
+
+void Shader::setProjectionMatrix(const float *projectionMatrix) const {
+    glUniformMatrix4fv(projectionMatrix_, 1, GL_FALSE, projectionMatrix);
+}
+
+void Shader::setLightDirection(const float *direction) const {
+    glUniform3fv(lightDirection_, 1, direction);
 }

--- a/app/src/main/cpp/Shader.h
+++ b/app/src/main/cpp/Shader.h
@@ -8,10 +8,10 @@ class Model;
 
 /*!
  * A class representing a simple shader program. It consists of vertex and fragment components. The
- * input attributes are a position (as a Vector3) and a uv (as a Vector2). It also takes a uniform
- * to be used as the entire model/view/projection matrix. The shader expects a single texture for
- * fragment shading, and does no other lighting calculations (thus no uniforms for lights or normal
- * attributes).
+ * input attributes are a position (as a Vector3) and a uv (as a Vector2). It exposes uniforms for
+ * the model, view, and projection matrices independently as well as a single directional light
+ * vector. The shader expects a single texture for fragment shading, and performs simple diffuse
+ * lighting.
  */
 class Shader {
 public:
@@ -32,7 +32,11 @@ public:
             const std::string &fragmentSource,
             const std::string &positionAttributeName,
             const std::string &uvAttributeName,
-            const std::string &projectionMatrixUniformName);
+            const std::string &modelMatrixUniformName,
+            const std::string &viewMatrixUniformName,
+            const std::string &projectionMatrixUniformName,
+            const std::string &lightDirectionUniformName,
+            const std::string &textureUniformName);
 
     inline ~Shader() {
         if (program_) {
@@ -61,7 +65,13 @@ public:
      * Sets the model/view/projection matrix in the shader.
      * @param projectionMatrix sixteen floats, column major, defining an OpenGL projection matrix.
      */
-    void setProjectionMatrix(float *projectionMatrix) const;
+    void setModelMatrix(const float *modelMatrix) const;
+
+    void setViewMatrix(const float *viewMatrix) const;
+
+    void setProjectionMatrix(const float *projectionMatrix) const;
+
+    void setLightDirection(const float *direction) const;
 
 private:
     /*!
@@ -83,16 +93,28 @@ private:
             GLuint program,
             GLint position,
             GLint uv,
-            GLint projectionMatrix)
+            GLint modelMatrix,
+            GLint viewMatrix,
+            GLint projectionMatrix,
+            GLint lightDirection,
+            GLint textureSampler)
             : program_(program),
               position_(position),
               uv_(uv),
-              projectionMatrix_(projectionMatrix) {}
+              modelMatrix_(modelMatrix),
+              viewMatrix_(viewMatrix),
+              projectionMatrix_(projectionMatrix),
+              lightDirection_(lightDirection),
+              textureSampler_(textureSampler) {}
 
     GLuint program_;
     GLint position_;
     GLint uv_;
+    GLint modelMatrix_;
+    GLint viewMatrix_;
     GLint projectionMatrix_;
+    GLint lightDirection_;
+    GLint textureSampler_;
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_SHADER_H

--- a/app/src/main/cpp/TextureAsset.cpp
+++ b/app/src/main/cpp/TextureAsset.cpp
@@ -1,7 +1,43 @@
 #include <android/imagedecoder.h>
+#include <algorithm>
+#include <cassert>
+#include <cmath>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
 #include "TextureAsset.h"
-#include "AndroidOut.h"
-#include "Utility.h"
+
+namespace {
+
+std::shared_ptr<TextureAsset> createTextureFromPixels(const uint8_t *data, int width, int height) {
+    GLuint textureId;
+    glGenTextures(1, &textureId);
+    glBindTexture(GL_TEXTURE_2D, textureId);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+
+    glTexImage2D(
+            GL_TEXTURE_2D,
+            0,
+            GL_RGBA,
+            width,
+            height,
+            0,
+            GL_RGBA,
+            GL_UNSIGNED_BYTE,
+            data);
+
+    glGenerateMipmap(GL_TEXTURE_2D);
+
+    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId));
+}
+
+} // namespace
 
 std::shared_ptr<TextureAsset>
 TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPath) {
@@ -37,44 +73,97 @@ TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPat
             upAndroidImageData->size());
     assert(decodeResult == ANDROID_IMAGE_DECODER_SUCCESS);
 
-    // Get an opengl texture
-    GLuint textureId;
-    glGenTextures(1, &textureId);
-    glBindTexture(GL_TEXTURE_2D, textureId);
-
-    // Clamp to the edge, you'll get odd results alpha blending if you don't
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-
-    // Load the texture into VRAM
-    glTexImage2D(
-            GL_TEXTURE_2D, // target
-            0, // mip level
-            GL_RGBA, // internal format, often advisable to use BGR
-            width, // width of the texture
-            height, // height of the texture
-            0, // border (always 0)
-            GL_RGBA, // format
-            GL_UNSIGNED_BYTE, // type
-            upAndroidImageData->data() // Data to upload
-    );
-
-    // generate mip levels. Not really needed for 2D, but good to do
-    glGenerateMipmap(GL_TEXTURE_2D);
+    auto texture = createTextureFromPixels(upAndroidImageData->data(), width, height);
 
     // cleanup helpers
     AImageDecoder_delete(pAndroidDecoder);
     AAsset_close(pAndroidRobotPng);
 
-    // Create a shared pointer so it can be cleaned up easily/automatically
-    return std::shared_ptr<TextureAsset>(new TextureAsset(textureId));
+    return texture;
 }
 
 TextureAsset::~TextureAsset() {
     // return texture resources
     glDeleteTextures(1, &textureID_);
     textureID_ = 0;
+}
+
+std::shared_ptr<TextureAsset> TextureAsset::createProceduralEarthTexture() {
+    constexpr int width = 256;
+    constexpr int height = 128;
+    constexpr float kPi = 3.14159265358979323846f;
+    constexpr float kTwoPi = 2.f * kPi;
+    constexpr float kHalfPi = 0.5f * kPi;
+
+    std::vector<uint8_t> pixels(width * height * 4);
+
+    for (int y = 0; y < height; ++y) {
+        float v = static_cast<float>(y) / static_cast<float>(height - 1);
+        float latitude = (v * kPi) - kHalfPi;
+        float latCos = std::cos(latitude);
+
+        for (int x = 0; x < width; ++x) {
+            float u = static_cast<float>(x) / static_cast<float>(width - 1);
+            float longitude = (u * kTwoPi) - kPi;
+
+            float ridge = std::sin(latitude * 3.5f + std::cos(longitude * 2.8f)) * 0.5f;
+            float swirl = std::sin(longitude * 1.5f + latitude * 2.3f);
+            float continentMask = latCos * 0.45f + ridge * 0.35f + swirl * 0.2f;
+
+            float coastline = std::sin(latitude * 12.f) * std::sin(longitude * 6.f) * 0.15f;
+            bool isLand = (continentMask + coastline) > 0.08f;
+
+            float iceAmount = std::clamp((std::fabs(latitude) - 1.0f) * 1.5f, 0.0f, 1.0f);
+
+            float r;
+            float g;
+            float b;
+
+            if (isLand) {
+                float elevation = std::sin(latitude * 5.0f + longitude * 1.7f) * 0.5f + 0.5f;
+                float moisture = std::sin(longitude * 2.4f - latitude * 1.9f) * 0.5f + 0.5f;
+                float grassy = std::clamp(0.4f + moisture * 0.4f - elevation * 0.2f, 0.0f, 1.0f);
+                float desert = std::clamp(elevation * 0.6f - moisture * 0.5f + 0.3f, 0.0f, 1.0f);
+                float mountain = std::clamp(elevation * 1.2f - 0.6f, 0.0f, 1.0f);
+
+                r = 0.08f + grassy * 0.25f + desert * 0.45f + mountain * 0.25f;
+                g = 0.16f + grassy * 0.55f + desert * 0.38f + mountain * 0.25f;
+                b = 0.06f + grassy * 0.20f + desert * 0.20f + mountain * 0.25f;
+
+                float coastalInfluence = std::clamp(0.3f - (continentMask + coastline - 0.08f), 0.0f, 0.3f) / 0.3f;
+                float blend = coastalInfluence * 0.4f;
+                r += (0.12f - r) * blend;
+                g += (0.25f - g) * blend;
+                b += (0.35f - b) * blend;
+            } else {
+                float depth = 0.5f + std::sin(latitude * 4.3f + longitude * 0.9f) * 0.25f;
+                float current = std::sin(longitude * 3.1f) * std::sin(latitude * 2.7f);
+                float turbulence = std::sin((longitude + latitude) * 5.7f) * 0.1f;
+
+                float ocean = depth + current * 0.15f + turbulence;
+                ocean = std::clamp(ocean, 0.0f, 1.0f);
+
+                r = 0.02f + ocean * 0.14f;
+                g = 0.09f + ocean * 0.32f;
+                b = 0.18f + ocean * 0.55f;
+            }
+
+            r = std::clamp(r + iceAmount * 0.6f, 0.0f, 1.0f);
+            g = std::clamp(g + iceAmount * 0.65f, 0.0f, 1.0f);
+            b = std::clamp(b + iceAmount * 0.7f, 0.0f, 1.0f);
+
+            float highlight = std::clamp(0.15f + latCos * 0.15f, 0.0f, 1.0f);
+            r = std::clamp(r + highlight * 0.05f, 0.0f, 1.0f);
+            g = std::clamp(g + highlight * 0.04f, 0.0f, 1.0f);
+            b = std::clamp(b + highlight * 0.03f, 0.0f, 1.0f);
+
+            size_t index = static_cast<size_t>(y * width + x) * 4;
+            pixels[index + 0] = static_cast<uint8_t>(std::clamp(r, 0.0f, 1.0f) * 255.0f);
+            pixels[index + 1] = static_cast<uint8_t>(std::clamp(g, 0.0f, 1.0f) * 255.0f);
+            pixels[index + 2] = static_cast<uint8_t>(std::clamp(b, 0.0f, 1.0f) * 255.0f);
+            pixels[index + 3] = 255;
+        }
+    }
+
+    return createTextureFromPixels(pixels.data(), width, height);
 }

--- a/app/src/main/cpp/TextureAsset.h
+++ b/app/src/main/cpp/TextureAsset.h
@@ -5,7 +5,6 @@
 #include <android/asset_manager.h>
 #include <GLES3/gl3.h>
 #include <string>
-#include <vector>
 
 class TextureAsset {
 public:
@@ -17,6 +16,8 @@ public:
      */
     static std::shared_ptr<TextureAsset>
     loadAsset(AAssetManager *assetManager, const std::string &assetPath);
+
+    static std::shared_ptr<TextureAsset> createProceduralEarthTexture();
 
     ~TextureAsset();
 

--- a/app/src/main/cpp/Utility.cpp
+++ b/app/src/main/cpp/Utility.cpp
@@ -2,6 +2,9 @@
 #include "AndroidOut.h"
 
 #include <GLES3/gl3.h>
+#include <algorithm>
+#include <cmath>
+#include <iterator>
 
 #define CHECK_ERROR(e) case e: aout << "GL Error: "#e << std::endl; break;
 
@@ -83,5 +86,72 @@ float *Utility::buildIdentityMatrix(float *outMatrix) {
     outMatrix[14] = 0.f;
     outMatrix[15] = 1.f;
 
+    return outMatrix;
+}
+
+float *Utility::buildPerspectiveMatrix(float *outMatrix, float fovYRadians, float aspect, float near,
+                                       float far) {
+    float f = 1.f / std::tan(fovYRadians / 2.f);
+
+    outMatrix[0] = f / aspect;
+    outMatrix[1] = 0.f;
+    outMatrix[2] = 0.f;
+    outMatrix[3] = 0.f;
+
+    outMatrix[4] = 0.f;
+    outMatrix[5] = f;
+    outMatrix[6] = 0.f;
+    outMatrix[7] = 0.f;
+
+    outMatrix[8] = 0.f;
+    outMatrix[9] = 0.f;
+    outMatrix[10] = (far + near) / (near - far);
+    outMatrix[11] = -1.f;
+
+    outMatrix[12] = 0.f;
+    outMatrix[13] = 0.f;
+    outMatrix[14] = (2.f * far * near) / (near - far);
+    outMatrix[15] = 0.f;
+
+    return outMatrix;
+}
+
+float *Utility::multiplyMatrix(float *outMatrix, const float *lhs, const float *rhs) {
+    float result[16];
+    for (int col = 0; col < 4; ++col) {
+        for (int row = 0; row < 4; ++row) {
+            result[col * 4 + row] =
+                    lhs[0 * 4 + row] * rhs[col * 4 + 0] +
+                    lhs[1 * 4 + row] * rhs[col * 4 + 1] +
+                    lhs[2 * 4 + row] * rhs[col * 4 + 2] +
+                    lhs[3 * 4 + row] * rhs[col * 4 + 3];
+        }
+    }
+
+    std::copy(std::begin(result), std::end(result), outMatrix);
+    return outMatrix;
+}
+
+float *Utility::buildRotationMatrixX(float *outMatrix, float radians) {
+    float s = std::sin(radians);
+    float c = std::cos(radians);
+
+    buildIdentityMatrix(outMatrix);
+    outMatrix[5] = c;
+    outMatrix[6] = s;
+    outMatrix[9] = -s;
+    outMatrix[10] = c;
+    return outMatrix;
+}
+
+float *Utility::buildRotationMatrixY(float *outMatrix, float radians) {
+    float s = std::sin(radians);
+    float c = std::cos(radians);
+
+    buildIdentityMatrix(outMatrix);
+    outMatrix[0] = c;
+    outMatrix[2] = -s;
+    outMatrix[8] = s;
+    outMatrix[10] = c;
     return outMatrix;
 }

--- a/app/src/main/cpp/Utility.h
+++ b/app/src/main/cpp/Utility.h
@@ -29,6 +29,22 @@ public:
             float far);
 
     static float *buildIdentityMatrix(float *outMatrix);
+
+    static float *buildPerspectiveMatrix(
+            float *outMatrix,
+            float fovYRadians,
+            float aspect,
+            float near,
+            float far);
+
+    static float *multiplyMatrix(
+            float *outMatrix,
+            const float *lhs,
+            const float *rhs);
+
+    static float *buildRotationMatrixX(float *outMatrix, float radians);
+
+    static float *buildRotationMatrixY(float *outMatrix, float radians);
 };
 
 #endif //ANDROIDGLINVESTIGATIONS_UTILITY_H


### PR DESCRIPTION
## Summary
- replace the bundled Earth PNG with a procedurally generated globe texture at runtime
- share OpenGL texture upload logic between asset decoding and procedural generation
- point the renderer at the new procedural texture builder

## Testing
- Not run (Android tooling is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68d99b4cace88329b08cc62845f5898f