### PR TITLE
Load earth texture from asset file

### DIFF
--- a/app/src/main/cpp/Renderer.cpp
+++ b/app/src/main/cpp/Renderer.cpp
@@ -339,7 +339,8 @@ void Renderer::createModels() {
         }
     }
 
-    auto spEarthTexture = TextureAsset::createProceduralEarthTexture();
+    auto *assetManager = app_->activity->assetManager;
+    auto spEarthTexture = TextureAsset::loadAsset(assetManager, "earth.png");
 
     models_.emplace_back(std::move(vertices), std::move(indices), spEarthTexture);
 }

--- a/app/src/main/cpp/TextureAsset.cpp
+++ b/app/src/main/cpp/TextureAsset.cpp
@@ -42,14 +42,17 @@ GLuint createTextureFromPixels(const uint8_t *data, int width, int height) {
 std::shared_ptr<TextureAsset>
 TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPath) {
     // Get the image from asset manager
-    auto pAndroidRobotPng = AAssetManager_open(
+    assert(assetManager != nullptr);
+
+    auto pAsset = AAssetManager_open(
             assetManager,
             assetPath.c_str(),
             AASSET_MODE_BUFFER);
+    assert(pAsset != nullptr);
 
     // Make a decoder to turn it into a texture
     AImageDecoder *pAndroidDecoder = nullptr;
-    auto result = AImageDecoder_createFromAAsset(pAndroidRobotPng, &pAndroidDecoder);
+    auto result = AImageDecoder_createFromAAsset(pAsset, &pAndroidDecoder);
     assert(result == ANDROID_IMAGE_DECODER_SUCCESS);
 
     // make sure we get 8 bits per channel out. RGBA order.
@@ -77,7 +80,7 @@ TextureAsset::loadAsset(AAssetManager *assetManager, const std::string &assetPat
 
     // cleanup helpers
     AImageDecoder_delete(pAndroidDecoder);
-    AAsset_close(pAndroidRobotPng);
+    AAsset_close(pAsset);
 
     return std::shared_ptr<TextureAsset>(new TextureAsset(textureId));
 }


### PR DESCRIPTION
## Summary
- load the earth model texture from a bundled earth.png asset via the asset manager
- add validation when opening the texture asset to ensure the asset manager and file are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9a11b13b88329b29b01a1bda6193f