### PR TITLE
Integrate NASA WorldWind globe

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -33,15 +33,6 @@ android {
     kotlinOptions {
         jvmTarget = "17"
     }
-    buildFeatures {
-        prefab = true
-    }
-    externalNativeBuild {
-        cmake {
-            path = file("src/main/cpp/CMakeLists.txt")
-            version = "3.22.1"
-        }
-    }
 }
 
 dependencies {
@@ -49,7 +40,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-    implementation(libs.androidx.games.activity)
+    implementation("gov.nasa.worldwind.android:worldwind:0.10.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -20,10 +20,6 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
-
-            <meta-data
-                android:name="android.app.lib_name"
-                android:value="earthzoo" />
         </activity>
     </application>
 

--- a/app/src/main/java/com/pykens/earthzoo/MainActivity.kt
+++ b/app/src/main/java/com/pykens/earthzoo/MainActivity.kt
@@ -1,29 +1,60 @@
 package com.pykens.earthzoo
 
-import android.view.View
-import com.google.androidgamesdk.GameActivity
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import gov.nasa.worldwind.WorldWind
+import gov.nasa.worldwind.WorldWindow
+import gov.nasa.worldwind.geom.LookAt
+import gov.nasa.worldwind.layer.AtmosphereLayer
+import gov.nasa.worldwind.layer.BackgroundLayer
+import gov.nasa.worldwind.layer.BlueMarbleLayer
+import gov.nasa.worldwind.layer.CompassLayer
+import gov.nasa.worldwind.navigator.LookAtNavigator
+import gov.nasa.worldwind.controller.BasicWorldWindowController
 
-class MainActivity : GameActivity() {
-    companion object {
-        init {
-            System.loadLibrary("earthzoo")
-        }
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var worldWindow: WorldWindow
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_main)
+
+        worldWindow = findViewById(R.id.world_window)
+        setupGlobe()
     }
 
-    override fun onWindowFocusChanged(hasFocus: Boolean) {
-        super.onWindowFocusChanged(hasFocus)
-        if (hasFocus) {
-            hideSystemUi()
-        }
+    override fun onResume() {
+        super.onResume()
+        worldWindow.onResume()
     }
 
-    private fun hideSystemUi() {
-        val decorView = window.decorView
-        decorView.systemUiVisibility = (View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
-                or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
-                or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                or View.SYSTEM_UI_FLAG_FULLSCREEN)
+    override fun onPause() {
+        worldWindow.onPause()
+        super.onPause()
+    }
+
+    override fun onDestroy() {
+        worldWindow.onDestroy()
+        super.onDestroy()
+    }
+
+    private fun setupGlobe() {
+        worldWindow.worldWindowController = BasicWorldWindowController()
+
+        worldWindow.layers.addLayer(BackgroundLayer())
+        worldWindow.layers.addLayer(BlueMarbleLayer())
+        worldWindow.layers.addLayer(AtmosphereLayer())
+        worldWindow.layers.addLayer(CompassLayer())
+
+        val lookAt = LookAt()
+        lookAt.set(0.0, 0.0, 0.0, WorldWind.ABSOLUTE, 6.5e6, 0.0, 45.0, 0.0)
+
+        val navigator = worldWindow.navigator
+        if (navigator is LookAtNavigator) {
+            navigator.lookAt = lookAt
+        } else {
+            worldWindow.navigator = LookAtNavigator().also { it.lookAt = lookAt }
+        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <gov.nasa.worldwind.WorldWindow
+        android:id="@+id/world_window"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+</FrameLayout>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
     <!-- Base application theme. -->
-    <style name="Theme.EarthZoo" parent="Theme.MaterialComponents.DayNight.DarkActionBar">
+    <style name="Theme.EarthZoo" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
         <item name="colorPrimary">@color/purple_500</item>
         <item name="colorPrimaryVariant">@color/purple_700</item>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ junitVersion = "1.3.0"
 espressoCore = "3.7.0"
 appcompat = "1.7.1"
 material = "1.13.0"
-gamesActivity = "1.2.2"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -16,7 +15,6 @@ androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "j
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "appcompat" }
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
-androidx-games-activity = { group = "androidx.games", name = "games-activity", version.ref = "gamesActivity" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- replace the native GameActivity shell with an AppCompat activity hosting a NASA WorldWind globe view
- add WorldWind layers for background, Blue Marble imagery, atmosphere, and compass controls with LookAt navigation
- simplify the Android build by removing the unused native build configuration and enable a fullscreen theme

## Testing
- ./gradlew help

------
https://chatgpt.com/codex/tasks/task_e_68d9a2fef99083298982dfe386fecce2