### PR TITLE
Remove earth image asset from changeset

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -40,7 +40,6 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
-    implementation("gov.nasa.worldwind.android:worldwind:0.10.0")
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/java/com/pykens/earthzoo/MainActivity.kt
+++ b/app/src/main/java/com/pykens/earthzoo/MainActivity.kt
@@ -1,60 +1,16 @@
 package com.pykens.earthzoo
 
 import android.os.Bundle
+import android.widget.ImageView
 import androidx.appcompat.app.AppCompatActivity
-import gov.nasa.worldwind.WorldWind
-import gov.nasa.worldwind.WorldWindow
-import gov.nasa.worldwind.geom.LookAt
-import gov.nasa.worldwind.layer.AtmosphereLayer
-import gov.nasa.worldwind.layer.BackgroundLayer
-import gov.nasa.worldwind.layer.BlueMarbleLayer
-import gov.nasa.worldwind.layer.CompassLayer
-import gov.nasa.worldwind.navigator.LookAtNavigator
-import gov.nasa.worldwind.controller.BasicWorldWindowController
 
 class MainActivity : AppCompatActivity() {
-
-    private lateinit var worldWindow: WorldWindow
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
-        worldWindow = findViewById(R.id.world_window)
-        setupGlobe()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        worldWindow.onResume()
-    }
-
-    override fun onPause() {
-        worldWindow.onPause()
-        super.onPause()
-    }
-
-    override fun onDestroy() {
-        worldWindow.onDestroy()
-        super.onDestroy()
-    }
-
-    private fun setupGlobe() {
-        worldWindow.worldWindowController = BasicWorldWindowController()
-
-        worldWindow.layers.addLayer(BackgroundLayer())
-        worldWindow.layers.addLayer(BlueMarbleLayer())
-        worldWindow.layers.addLayer(AtmosphereLayer())
-        worldWindow.layers.addLayer(CompassLayer())
-
-        val lookAt = LookAt()
-        lookAt.set(0.0, 0.0, 0.0, WorldWind.ABSOLUTE, 6.5e6, 0.0, 45.0, 0.0)
-
-        val navigator = worldWindow.navigator
-        if (navigator is LookAtNavigator) {
-            navigator.lookAt = lookAt
-        } else {
-            worldWindow.navigator = LookAtNavigator().also { it.lookAt = lookAt }
-        }
+        val earthImage: ImageView = findViewById(R.id.earth_image)
+        earthImage.setImageResource(R.drawable.earth)
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,10 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@android:color/black">
 
-    <gov.nasa.worldwind.WorldWindow
-        android:id="@+id/world_window"
+    <ImageView
+        android:id="@+id/earth_image"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        android:adjustViewBounds="true"
+        android:contentDescription="@string/earth_content_description"
+        android:scaleType="fitCenter" />
 </FrameLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">EarthZoo</string>
+    <string name="earth_content_description">Illustration of Earth</string>
 </resources>


### PR DESCRIPTION
## Summary
- remove the NASA WorldWind dependency and associated globe setup code
- swap the globe layout for an ImageView that shows a new earth illustration
- remove the earth.png drawable from the changeset so it can be supplied manually

## Testing
- ./gradlew test *(fails: SDK location not found in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d9a94412088329ab0b3753d36f5b4f